### PR TITLE
Fix fields creation during update

### DIFF
--- a/src/ModifiedNovaInlineRelationship.php
+++ b/src/ModifiedNovaInlineRelationship.php
@@ -366,9 +366,11 @@ class ModifiedNovaInlineRelationship extends Field
      */
     protected function getResourceField($props, $key): Field
     {
-        $attrs = ['name' => $key, 'attribute' => $key];
-
-        return resolve($props['component'], $attrs);
+        /** @var newField Field */
+        $newField = clone $props['field'];
+        $newField->name = $key;
+        $newField->attribute = $key;
+        return $newField;
     }
 
     /**


### PR DESCRIPTION
Fix fields creation during update the closure now are supported.

Now it's possible to use:
```
Image::make(__('Image'), 'image_url')
                ->path('abc')
                ->storeAs(function (Request $request) {
                    return ....;
                })
```